### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - tests
-- remove NZB.filenames and NZB.extensions
+- remove NZB.filestems and NZB.extensions
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Ravencentric/nzb-rs/compare/v0.1.3...v0.2.0) - 2025-01-20
+
+### Fixed
+
+- tests
+- remove NZB.filenames and NZB.extensions
+
+### Other
+
+- update deps
+- use cached install
+- remove paths
+- use pat
+
 ## [0.1.3](https://github.com/Ravencentric/nzb-rs/compare/v0.1.2...v0.1.3) - 2025-01-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.1.3"
+version = "0.2.0"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `nzb-rs`: 0.1.3 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `nzb-rs` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  NZB::filestems, previously in file /tmp/.tmpjRP3XS/nzb-rs/src/lib.rs:323
  NZB::extensions, previously in file /tmp/.tmpjRP3XS/nzb-rs/src/lib.rs:328
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/Ravencentric/nzb-rs/compare/v0.1.3...v0.2.0) - 2025-01-20

### Fixed

- tests
- remove NZB.filenames and NZB.extensions

### Other

- update deps
- use cached install
- remove paths
- use pat
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).