### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Ravencentric/nzb-rs/compare/v0.2.0...v0.3.0) - 2025-01-23
+
+### Fixed
+
+- refactor lib.rs
+- refactor parser.rs
+- [**breaking**] rename public API
+
+### Other
+
+- fmt
+
 ## [0.2.0](https://github.com/Ravencentric/nzb-rs/compare/v0.1.3...v0.2.0) - 2025-01-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.2.0"
+version = "0.3.0"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `nzb-rs`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `nzb-rs` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct nzb_rs::NZB, previously in file /tmp/.tmplupVnI/nzb-rs/src/lib.rs:237
  struct nzb_rs::InvalidNZBError, previously in file /tmp/.tmplupVnI/nzb-rs/src/lib.rs:75
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/Ravencentric/nzb-rs/compare/v0.2.0...v0.3.0) - 2025-01-23

### Fixed

- refactor lib.rs
- refactor parser.rs
- [**breaking**] rename public API

### Other

- fmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).