### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Ravencentric/nzb-rs/compare/v0.3.1...v0.4.0) - 2025-01-27
+
+### Fixed
+
+- [**breaking**] rename `File.datetime` to `File.posted_at`
+
 ## [0.3.1](https://github.com/Ravencentric/nzb-rs/compare/v0.3.0...v0.3.1) - 2025-01-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.3.1"
+version = "0.4.0"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `nzb-rs`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `nzb-rs` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field File.posted_at in /tmp/.tmpB8EFr5/nzb-rs/src/lib.rs:93

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field datetime of struct File, previously in file /tmp/.tmp0tI4GM/nzb-rs/src/lib.rs:93
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/Ravencentric/nzb-rs/compare/v0.3.1...v0.4.0) - 2025-01-27

### Fixed

- [**breaking**] rename `File.datetime` to `File.posted_at`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).