### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/Ravencentric/nzb-rs/compare/v0.4.0...v0.4.1) - 2025-01-28
+
+### Fixed
+
+- update version in readme
+- sort `Nzb.files`
+
+### Other
+
+- *(deps)* bump serde_json in the actions group (#11)
+- add cargo to dependabot
+
 ## [0.4.0](https://github.com/Ravencentric/nzb-rs/compare/v0.3.1...v0.4.0) - 2025-01-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.4.0"
+version = "0.4.1"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `nzb-rs`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/Ravencentric/nzb-rs/compare/v0.4.0...v0.4.1) - 2025-01-28

### Fixed

- update version in readme
- sort `Nzb.files`

### Other

- *(deps)* bump serde_json in the actions group (#11)
- add cargo to dependabot
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).