### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/Ravencentric/nzb-rs/compare/v0.4.2...v0.4.3) - 2025-02-05
+
+### Added
+
+- add `Nzb.par2_files`, `Nzb.has_extension`, and `File.has_extension`
+
+### Fixed
+
+- update readme
+
 ## [0.4.2](https://github.com/Ravencentric/nzb-rs/compare/v0.4.1...v0.4.2) - 2025-01-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.4.2"
+version = "0.4.3"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/Ravencentric/nzb-rs/compare/v0.4.2...v0.4.3) - 2025-02-05

### Added

- add `Nzb.par2_files`, `Nzb.has_extension`, and `File.has_extension`

### Fixed

- update readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).