### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/Ravencentric/nzb-rs/compare/v0.4.3...v0.4.4) - 2025-02-05
+
+### Fixed
+
+- replace pip with cargo (lol)
+
 ## [0.4.3](https://github.com/Ravencentric/nzb-rs/compare/v0.4.2...v0.4.3) - 2025-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.4.3"
+version = "0.4.4"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.4.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/Ravencentric/nzb-rs/compare/v0.4.3...v0.4.4) - 2025-02-05

### Fixed

- replace pip with cargo (lol)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).