### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/Ravencentric/nzb-rs/compare/v0.4.4...v0.5.0) - 2025-02-08
+
+### Added
+
+- [**breaking**] new errors enums with fine grained members
+- support reading from (gzipped) text file
+
+### Fixed
+
+- non_existent_file test
+- serde tests
+- more tests
+
+### Other
+
+- fmt
+
 ## [0.4.4](https://github.com/Ravencentric/nzb-rs/compare/v0.4.3...v0.4.4) - 2025-02-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.4.4"
+version = "0.5.0"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/Ravencentric/nzb-rs/compare/v0.4.4...v0.5.0) - 2025-02-08

### Added

- [**breaking**] new errors enums with fine grained members
- support reading from (gzipped) text file

### Fixed

- non_existent_file test
- serde tests
- more tests

### Other

- fmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).