### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/Ravencentric/nzb-rs/compare/v0.5.0...v0.5.1) - 2025-02-08
+
+### Fixed
+
+- readme
+- docstring
+
 ## [0.5.0](https://github.com/Ravencentric/nzb-rs/compare/v0.4.4...v0.5.0) - 2025-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.5.0"
+version = "0.5.1"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/Ravencentric/nzb-rs/compare/v0.5.0...v0.5.1) - 2025-02-08

### Fixed

- readme
- docstring
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).