### PR TITLE
chore: release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/Ravencentric/nzb-rs/compare/v0.5.5...v0.5.6) - 2025-02-24
+
+### Other
+
+- *(deps)* bump the actions group with 3 updates (#21)
+
 ## [0.5.5](https://github.com/Ravencentric/nzb-rs/compare/v0.5.4...v0.5.5) - 2025-02-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "chrono",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.5.5"
+version = "0.5.6"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.5.5 -> 0.5.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.6](https://github.com/Ravencentric/nzb-rs/compare/v0.5.5...v0.5.6) - 2025-02-24

### Other

- *(deps)* bump the actions group with 3 updates (#21)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).