### PR TITLE
chore: release v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/Ravencentric/nzb-rs/compare/v0.5.7...v0.5.8) - 2025-04-07
+
+### Other
+
+- *(deps)* bump flate2 from 1.1.0 to 1.1.1 in the actions group ([#26](https://github.com/Ravencentric/nzb-rs/pull/26))
+
 ## [0.5.7](https://github.com/Ravencentric/nzb-rs/compare/v0.5.6...v0.5.7) - 2025-03-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.5.7"
+version = "0.5.8"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.5.7 -> 0.5.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.8](https://github.com/Ravencentric/nzb-rs/compare/v0.5.7...v0.5.8) - 2025-04-07

### Other

- *(deps)* bump flate2 from 1.1.0 to 1.1.1 in the actions group ([#26](https://github.com/Ravencentric/nzb-rs/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).