### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/Ravencentric/nzb-rs/compare/v0.5.13...v0.6.0) - 2025-08-21
+
+### Fixed
+
+- use .start() instead of .range()
+- refactor stem and extension extractor
+- more robust extension and stem parser
+- implement a basic "natsort" for Nzb.files
+- ensure nzb has atleast one non-par2 file
+
+### Other
+
+- *(deps)* bump taiki-e/install-action in the actions group ([#40](https://github.com/Ravencentric/nzb-rs/pull/40))
+- *(deps)* bump the actions group with 2 updates ([#42](https://github.com/Ravencentric/nzb-rs/pull/42))
+- enable rust-toolchain updates in dependabot
+
 ## [0.5.13](https://github.com/Ravencentric/nzb-rs/compare/v0.5.12...v0.5.13) - 2025-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "nzb-rs"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nzb-rs"
-version = "0.5.13"
+version = "0.6.0"
 description = "A spec compliant parser for NZB files"
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `nzb-rs`: 0.5.13 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `nzb-rs` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ParseNzbError::FileAttribute 3 -> 4 in /tmp/.tmpXRjgIx/nzb-rs/src/errors.rs:41
  variant ParseNzbError::XmlSyntax 4 -> 5 in /tmp/.tmpXRjgIx/nzb-rs/src/errors.rs:48

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant ParseNzbError:OnlyPar2Files in /tmp/.tmpXRjgIx/nzb-rs/src/errors.rs:37

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  ParseNzbError::FileAttribute moved from position 4 to 5, in /tmp/.tmpXRjgIx/nzb-rs/src/errors.rs:41
  ParseNzbError::XmlSyntax moved from position 5 to 6, in /tmp/.tmpXRjgIx/nzb-rs/src/errors.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/Ravencentric/nzb-rs/compare/v0.5.13...v0.6.0) - 2025-08-21

### Fixed

- use .start() instead of .range()
- refactor stem and extension extractor
- more robust extension and stem parser
- implement a basic "natsort" for Nzb.files
- ensure nzb has atleast one non-par2 file

### Other

- *(deps)* bump taiki-e/install-action in the actions group ([#40](https://github.com/Ravencentric/nzb-rs/pull/40))
- *(deps)* bump the actions group with 2 updates ([#42](https://github.com/Ravencentric/nzb-rs/pull/42))
- enable rust-toolchain updates in dependabot
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).